### PR TITLE
[FEAT] 데이터 계층 구현 및 API 통신 준비

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,7 @@ android {
 
     defaultConfig {
         applicationId "com.teamnoyes.balancevote"
-        minSdk 21
+        minSdk 23
         targetSdk 31
         versionCode 1
         versionName "1.0"
@@ -66,6 +66,8 @@ dependencies {
     androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
     debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
 
+    implementation "androidx.hilt:hilt-navigation-compose:1.0.0"
+
     implementation "com.google.accompanist:accompanist-pager:0.23.1"
     implementation "com.google.accompanist:accompanist-pager-indicators:0.23.1"
     implementation "com.google.accompanist:accompanist-appcompat-theme:0.23.1"
@@ -76,4 +78,16 @@ dependencies {
 
     implementation "com.google.dagger:hilt-android:2.40.5"
     kapt "com.google.dagger:hilt-android-compiler:2.40.5"
+
+    implementation "io.reactivex.rxjava3:rxandroid:3.0.0"
+    implementation "io.reactivex.rxjava3:rxjava:3.1.4"
+
+    implementation "com.squareup.okhttp3:okhttp:4.9.1"
+    implementation "com.squareup.okhttp3:logging-interceptor:4.9.1"
+    implementation "com.squareup.retrofit2:retrofit:2.9.0"
+    implementation "com.squareup.retrofit2:converter-moshi:2.9.0"
+    implementation "com.squareup.retrofit2:converter-scalars:2.9.0"
+    implementation "com.squareup.retrofit2:adapter-rxjava3:2.9.0"
+    implementation "com.squareup.moshi:moshi:1.13.0"
+    kapt "com.squareup.moshi:moshi-kotlin-codegen:1.13.0"
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.teamnoyes.balancevote">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:name=".BVApplication"
         android:allowBackup="true"
@@ -9,11 +11,11 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.BalanceVote">
+        android:theme="@style/Theme.BalanceVote"
+        android:usesCleartextTraffic="true">
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:label="@string/app_name"
             android:theme="@style/Theme.BalanceVote">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/teamnoyes/balancevote/BVApp.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/BVApp.kt
@@ -4,12 +4,14 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation
 import com.google.accompanist.insets.ProvideWindowInsets
 import com.teamnoyes.balancevote.presentation.ui.screens.home.HomeScreen
+import com.teamnoyes.balancevote.presentation.ui.screens.home.HomeViewModel
 import com.teamnoyes.balancevote.presentation.ui.screens.post.PostScreen
 import com.teamnoyes.balancevote.presentation.ui.screens.settings.SettingsScreen
 import com.teamnoyes.balancevote.presentation.ui.screens.vote.VoteScreen
@@ -57,7 +59,10 @@ fun BVApp() {
 }
 
 fun NavGraphBuilder.addHomeGraph() {
-    composable(Screen.HOME.route) { HomeScreen() }
+    composable(Screen.HOME.route) {
+        val homeViewModel = hiltViewModel<HomeViewModel>()
+        HomeScreen(homeViewModel)
+    }
     composable(Screen.POST.route) { PostScreen() }
     composable(Screen.SETTINGS.route) { SettingsScreen() }
 }

--- a/app/src/main/java/com/teamnoyes/balancevote/data/api/BVService.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/data/api/BVService.kt
@@ -1,0 +1,11 @@
+package com.teamnoyes.balancevote.data.api
+
+import com.teamnoyes.balancevote.data.response.AllVotePostResponse
+import io.reactivex.rxjava3.core.Single
+import retrofit2.http.GET
+
+interface BVService {
+//    이후 Pagination 적용 필요. 현재는 Single로 전체 받기
+    @GET("/post/vote-post")
+    fun getAllVotePost() : Single<AllVotePostResponse>
+}

--- a/app/src/main/java/com/teamnoyes/balancevote/data/datasource/RemoteVotePostDataSource.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/data/datasource/RemoteVotePostDataSource.kt
@@ -1,0 +1,11 @@
+package com.teamnoyes.balancevote.data.datasource
+
+import com.teamnoyes.balancevote.data.api.BVService
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class RemoteVotePostDataSource @Inject constructor(private val api: BVService) {
+
+    fun getAllVotePost() = api.getAllVotePost()
+}

--- a/app/src/main/java/com/teamnoyes/balancevote/data/model/Pageable.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/data/model/Pageable.kt
@@ -1,0 +1,13 @@
+package com.teamnoyes.balancevote.data.model
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class Pageable(
+    val sort: Sort,
+    val offset: Long,
+    val pageNumber: Int,
+    val pageSize: Int,
+    val paged: Boolean,
+    val unpaged: Boolean
+)

--- a/app/src/main/java/com/teamnoyes/balancevote/data/model/Sort.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/data/model/Sort.kt
@@ -1,0 +1,6 @@
+package com.teamnoyes.balancevote.data.model
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class Sort(val empty: Boolean, val sorted: Boolean, val unsorted: Boolean)

--- a/app/src/main/java/com/teamnoyes/balancevote/data/model/VotePost.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/data/model/VotePost.kt
@@ -1,0 +1,14 @@
+package com.teamnoyes.balancevote.data.model
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class VotePost(
+    val id: Long,
+    val postId: String,
+    val selectionOne: String,
+    val selectionTwo: String,
+    val uuid: String,
+    val voteCntOne: Int,
+    val voteCntTwo: Int,
+)

--- a/app/src/main/java/com/teamnoyes/balancevote/data/repository/VotePostRepository.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/data/repository/VotePostRepository.kt
@@ -1,0 +1,11 @@
+package com.teamnoyes.balancevote.data.repository
+
+import com.teamnoyes.balancevote.data.datasource.RemoteVotePostDataSource
+import javax.inject.Inject
+
+class VotePostRepository @Inject constructor(
+    private val remoteVotePostDataSource: RemoteVotePostDataSource
+) {
+
+    fun getAllVotePost() = remoteVotePostDataSource.getAllVotePost()
+}

--- a/app/src/main/java/com/teamnoyes/balancevote/data/response/AllVotePostResponse.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/data/response/AllVotePostResponse.kt
@@ -1,0 +1,21 @@
+package com.teamnoyes.balancevote.data.response
+
+import com.squareup.moshi.JsonClass
+import com.teamnoyes.balancevote.data.model.Pageable
+import com.teamnoyes.balancevote.data.model.Sort
+import com.teamnoyes.balancevote.data.model.VotePost
+
+@JsonClass(generateAdapter = true)
+data class AllVotePostResponse(
+    val content: List<VotePost>,
+    val pageable: Pageable,
+    val totalPages: Int,
+    val totalElements: Int,
+    val last: Boolean,
+    val size: Int,
+    val number: Int,
+    val sort: Sort,
+    val numberOfElements: Int,
+    val first: Boolean,
+    val empty: Boolean,
+)

--- a/app/src/main/java/com/teamnoyes/balancevote/network/BVApiService.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/network/BVApiService.kt
@@ -1,0 +1,28 @@
+package com.teamnoyes.balancevote.network
+
+import com.squareup.moshi.Moshi
+import com.teamnoyes.balancevote.data.api.BVService
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import io.reactivex.rxjava3.schedulers.Schedulers
+import retrofit2.Retrofit
+import retrofit2.adapter.rxjava3.RxJava3CallAdapterFactory
+import retrofit2.converter.moshi.MoshiConverterFactory
+
+const val BASE_URL = "http://ec2-3-36-94-154.ap-northeast-2.compute.amazonaws.com:8080"
+
+@Module
+@InstallIn(SingletonComponent::class)
+object BVApiService {
+    val moshi = Moshi.Builder().build()
+
+    @Provides
+    fun retrofit(): BVService = Retrofit.Builder()
+        .addConverterFactory(MoshiConverterFactory.create(moshi))
+        .addCallAdapterFactory(RxJava3CallAdapterFactory.createWithScheduler(Schedulers.io()))
+        .baseUrl(BASE_URL)
+        .build()
+        .create(BVService::class.java)
+}

--- a/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/home/HomeScreen.kt
@@ -6,9 +6,10 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Card
-import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -17,18 +18,18 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.google.accompanist.pager.ExperimentalPagerApi
 import com.google.accompanist.pager.HorizontalPager
 import com.google.accompanist.pager.HorizontalPagerIndicator
 import com.google.accompanist.pager.rememberPagerState
 import com.teamnoyes.balancevote.R
-import com.teamnoyes.balancevote.presentation.ui.widget.BVAppBar
-import com.teamnoyes.balancevote.presentation.ui.widget.BVBottomNavigation
 import com.teamnoyes.balancevote.presentation.ui.widget.BVGraph
 import com.teamnoyes.balancevote.presentation.ui.widget.BVTextButton
 
 @Composable
-fun HomeScreen() {
+fun HomeScreen(homeViewModel: HomeViewModel = viewModel()) {
+    val allVoteList = remember { mutableStateOf(homeViewModel.getAllVotePost()) }
     HomeScreenBody(bottomNavPadding = PaddingValues(bottom = 48.dp))
 }
 

--- a/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/home/HomeViewModel.kt
@@ -1,4 +1,39 @@
 package com.teamnoyes.balancevote.presentation.ui.screens.home
 
-class HomeViewModel {
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import com.teamnoyes.balancevote.data.repository.VotePostRepository
+import com.teamnoyes.balancevote.data.response.AllVotePostResponse
+import dagger.hilt.android.lifecycle.HiltViewModel
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
+import io.reactivex.rxjava3.disposables.CompositeDisposable
+import io.reactivex.rxjava3.observers.DisposableSingleObserver
+import io.reactivex.rxjava3.schedulers.Schedulers
+import javax.inject.Inject
+
+@HiltViewModel
+class HomeViewModel @Inject constructor(
+    private val votePostRepository: VotePostRepository,
+) : ViewModel() {
+
+    private val disposable = CompositeDisposable()
+
+    fun getAllVotePost() {
+        disposable.add(votePostRepository.getAllVotePost()
+            .subscribeOn(Schedulers.newThread())
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribeWith(object : DisposableSingleObserver<AllVotePostResponse>() {
+                override fun onSuccess(t: AllVotePostResponse) {
+                    println(t)
+                }
+
+                override fun onError(e: Throwable) {
+                    Log.d(TAG, e.stackTraceToString())
+                }
+            }))
+    }
+
+    companion object {
+        const val TAG = "HomeViewModel"
+    }
 }


### PR DESCRIPTION
# 관련 Issues
* closes #33 
* closes #34 
* closes #35 
* closes #36 

# 구현 내용

## 데이터 계층 구현
- `VotePostRepository`, `RemoteVotePostDataSource` 클래스 추가

## Hilt 라이브러리 적용
- Hilt 라이브러리를 프로젝트 전체에 적용

## API 통신 구현
- Retrofit + Moshi 라이브러리 조합
- Moshi 라이브러리는 Code Gen 방식 사용 (Data Class에 `@JsonClass(generateAdapter = true)` Annotation)
  - Code Gen 방식이 Reflection 대비 빌드 시간은 느려지나, 런타임 성능이 향상됨 [참조](https://stackoverflow.com/questions/58501918/whats-the-use-of-moshis-kotlin-codegen)

## RxJava 적용
- Retrofit 빌드시 `.addCallAdapterFactory(RxJava3CallAdapterFactory.createWithScheduler(Schedulers.io()))` 로 Adapter 추가
- 이번 PR에서는 Observable은 없고, Single만 사용하여 원샷 호출만 함