### PR TITLE
[FEAT] New Votes 리스트 구현

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -90,4 +90,16 @@ dependencies {
     implementation "com.squareup.retrofit2:adapter-rxjava3:2.9.0"
     implementation "com.squareup.moshi:moshi:1.13.0"
     kapt "com.squareup.moshi:moshi-kotlin-codegen:1.13.0"
+
+    implementation "androidx.paging:paging-runtime:$paging_version"
+    implementation "androidx.paging:paging-rxjava3:$paging_version"
+    implementation "androidx.paging:paging-compose:1.0.0-alpha14"
+
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-compose:$lifecycle_version"
+
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.0"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-rx3:1.6.0"
+
+
 }

--- a/app/src/main/java/com/teamnoyes/balancevote/data/api/BVService.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/data/api/BVService.kt
@@ -3,9 +3,14 @@ package com.teamnoyes.balancevote.data.api
 import com.teamnoyes.balancevote.data.response.AllVotePostResponse
 import io.reactivex.rxjava3.core.Single
 import retrofit2.http.GET
+import retrofit2.http.Query
 
 interface BVService {
-//    이후 Pagination 적용 필요. 현재는 Single로 전체 받기
+    //    이후 Pagination 적용 필요. 현재는 Single로 전체 받기
     @GET("/post/vote-post")
-    fun getAllVotePost() : Single<AllVotePostResponse>
+    fun getAllVotePost(
+        @Query("page") page: Int = 0,
+        @Query("size") size: Int = 20,
+        @Query("sortBy") sortBy: String = "writer-asc",
+    ): Single<AllVotePostResponse>
 }

--- a/app/src/main/java/com/teamnoyes/balancevote/data/datasource/VotePostPagingSource.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/data/datasource/VotePostPagingSource.kt
@@ -1,0 +1,42 @@
+package com.teamnoyes.balancevote.data.datasource
+
+import androidx.paging.PagingState
+import androidx.paging.rxjava3.RxPagingSource
+import com.teamnoyes.balancevote.data.api.BVService
+import com.teamnoyes.balancevote.data.model.VotePost
+import io.reactivex.rxjava3.core.Single
+import io.reactivex.rxjava3.schedulers.Schedulers
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class VotePostPagingSource @Inject constructor(private val api: BVService) :
+    RxPagingSource<Int, VotePost>() {
+    override fun getRefreshKey(state: PagingState<Int, VotePost>): Int? {
+//        수정 필요
+        println(1)
+        val anchorPosition = state.anchorPosition ?: return null
+        println(2)
+        val anchorPage = state.closestPageToPosition(anchorPosition) ?: return null
+        println(3)
+        val prevKey = anchorPage.prevKey
+        println(4)
+        if (prevKey != null) return prevKey + 1
+        println(5)
+        val nextKey = anchorPage.nextKey
+        println(6)
+        if (nextKey != null) return nextKey - 1
+        println(7)
+        return null
+    }
+
+    override fun loadSingle(params: LoadParams<Int>): Single<LoadResult<Int, VotePost>> {
+        println(1000)
+//        이 값이 계속 null이 나와서 같은 값이 반복됨
+        val nextPageNumber = params.key ?: 0
+
+        return api.getAllVotePost(params.key ?: 0, 10, "writer-asc").subscribeOn(Schedulers.io())
+            .map { result -> LoadResult.Page(data = result.content, null, nextPageNumber+1) }
+    }
+
+}

--- a/app/src/main/java/com/teamnoyes/balancevote/data/repository/VotePostRepository.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/data/repository/VotePostRepository.kt
@@ -1,11 +1,18 @@
 package com.teamnoyes.balancevote.data.repository
 
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.rxjava3.flowable
+import com.teamnoyes.balancevote.data.datasource.VotePostPagingSource
 import com.teamnoyes.balancevote.data.datasource.RemoteVotePostDataSource
 import javax.inject.Inject
 
 class VotePostRepository @Inject constructor(
-    private val remoteVotePostDataSource: RemoteVotePostDataSource
+    private val remoteVotePostDataSource: RemoteVotePostDataSource,
+    private val votePostPagingSource: VotePostPagingSource,
 ) {
 
     fun getAllVotePost() = remoteVotePostDataSource.getAllVotePost()
+
+    fun paging() = Pager(config = PagingConfig(pageSize = 20), pagingSourceFactory = { votePostPagingSource }).flowable
 }

--- a/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/home/HomeScreen.kt
@@ -19,23 +19,30 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.paging.PagingData
+import androidx.paging.compose.collectAsLazyPagingItems
+import androidx.paging.compose.items
 import com.google.accompanist.pager.ExperimentalPagerApi
 import com.google.accompanist.pager.HorizontalPager
 import com.google.accompanist.pager.HorizontalPagerIndicator
 import com.google.accompanist.pager.rememberPagerState
 import com.teamnoyes.balancevote.R
+import com.teamnoyes.balancevote.data.model.VotePost
 import com.teamnoyes.balancevote.presentation.ui.widget.BVGraph
 import com.teamnoyes.balancevote.presentation.ui.widget.BVTextButton
+import io.reactivex.rxjava3.core.Flowable
+import kotlinx.coroutines.reactive.asFlow
 
 @Composable
 fun HomeScreen(homeViewModel: HomeViewModel = viewModel()) {
-    val allVoteList = remember { mutableStateOf(homeViewModel.getAllVotePost()) }
-    HomeScreenBody(bottomNavPadding = PaddingValues(bottom = 48.dp))
+    val allVotePostList = remember { mutableStateOf(homeViewModel.getPaging()) }
+    HomeScreenBody(pager = allVotePostList.value, bottomNavPadding = PaddingValues(bottom = 48.dp))
 }
 
 @OptIn(ExperimentalPagerApi::class, ExperimentalFoundationApi::class)
 @Composable
-fun HomeScreenBody(bottomNavPadding: PaddingValues) {
+fun HomeScreenBody(pager: Flowable<PagingData<VotePost>>, bottomNavPadding: PaddingValues) {
+    val lazyPagingItems = pager.asFlow().collectAsLazyPagingItems()
     Box(modifier = Modifier.padding(bottomNavPadding)) {
         LazyColumn(modifier = Modifier) {
             items(count = 1) {
@@ -62,8 +69,8 @@ fun HomeScreenBody(bottomNavPadding: PaddingValues) {
                 HomeText(text = "New Votes")
 
             }
-            items(count = 20) {
-                BVTextButton(text = "test",
+            items(lazyPagingItems) { votePost ->
+                BVTextButton(text = "${votePost?.id} ${votePost?.selectionOne} vs ${votePost?.selectionTwo}",
                     onClick = {},
                     isSelected = false
                 )

--- a/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/home/HomeViewModel.kt
@@ -1,14 +1,15 @@
 package com.teamnoyes.balancevote.presentation.ui.screens.home
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.paging.PagingData
+import androidx.paging.rxjava3.cachedIn
+import com.teamnoyes.balancevote.data.model.VotePost
 import com.teamnoyes.balancevote.data.repository.VotePostRepository
-import com.teamnoyes.balancevote.data.response.AllVotePostResponse
 import dagger.hilt.android.lifecycle.HiltViewModel
-import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
+import io.reactivex.rxjava3.core.Flowable
 import io.reactivex.rxjava3.disposables.CompositeDisposable
-import io.reactivex.rxjava3.observers.DisposableSingleObserver
-import io.reactivex.rxjava3.schedulers.Schedulers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import javax.inject.Inject
 
 @HiltViewModel
@@ -18,20 +19,27 @@ class HomeViewModel @Inject constructor(
 
     private val disposable = CompositeDisposable()
 
-    fun getAllVotePost() {
-        disposable.add(votePostRepository.getAllVotePost()
-            .subscribeOn(Schedulers.newThread())
-            .observeOn(AndroidSchedulers.mainThread())
-            .subscribeWith(object : DisposableSingleObserver<AllVotePostResponse>() {
-                override fun onSuccess(t: AllVotePostResponse) {
-                    println(t)
-                }
+//    Single은 이후에 Hot Votes에 사용하는 것으로
+//    fun getAllVotePost() {
+//        disposable.add(votePostRepository.getAllVotePost()
+//            .subscribeOn(Schedulers.newThread())
+//            .observeOn(AndroidSchedulers.mainThread())
+//            .subscribeWith(object : DisposableSingleObserver<AllVotePostResponse>() {
+//                override fun onSuccess(t: AllVotePostResponse) {
+//                    println(t)
+//                }
+//
+//                override fun onError(e: Throwable) {
+//                    Log.d(TAG, e.stackTraceToString())
+//                }
+//            }))
+//    }
 
-                override fun onError(e: Throwable) {
-                    Log.d(TAG, e.stackTraceToString())
-                }
-            }))
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun getPaging(): Flowable<PagingData<VotePost>> {
+        return votePostRepository.paging().cachedIn(viewModelScope)
     }
+
 
     companion object {
         const val TAG = "HomeViewModel"

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,8 @@
 buildscript {
     ext {
         compose_version = '1.1.0'
+        paging_version = '3.1.1'
+        lifecycle_version = '2.4.1'
     }
     repositories {
         google()


### PR DESCRIPTION
# 관련 Issue
 * closes #39 

# 요약

## build.gradle

```kotlin
    implementation "androidx.paging:paging-runtime:$paging_version"
    implementation "androidx.paging:paging-rxjava3:$paging_version"
    implementation "androidx.paging:paging-compose:1.0.0-alpha14"
```
- 페이징 라이브러리, RxJava3 연동, Jetpack Compose 연동

```kotlin
    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
    implementation "androidx.lifecycle:lifecycle-viewmodel-compose:$lifecycle_version"
```
- ViewModel 수명주기 연동을 위한 라이브러리 ex: viewModelScope

```kotlin
    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.0"
    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-rx3:1.6.0"
```
- 안드로이드 코루틴 연동, RxJava와 코루틴 연동 ex: asFlow로 RxJava Flowable을 Coroutines Flow로 변환

## 페이징 라이브러리 구조

### Data Layer
- VotePostPagingSource
-  VotePostRepository

### UI Layer
- HomeViewModel
- HomeScreen

## 주요사항
Paging 라이브러리에서 Compose의 `LazyColumn`에 값을 전달하기 위해서는 [LazyPagingItems](https://developer.android.com/reference/kotlin/androidx/paging/compose/LazyPagingItems?hl=ko)를 `LazyColumn`의 `items`의 파라미터로 전달해야 함.
그런데 `LazyPagingItems`의 인스턴스는 [collectAsLazyPagingItems()](https://developer.android.com/reference/kotlin/androidx/paging/compose/package-summary?hl=ko#(kotlinx.coroutines.flow.Flow).collectAsLazyPagingItems()) 함수로만 생성할 수 있는 것으로 보이는데 공식문서 검토 결과 해당 함수는 Coroutines Flow에만 사용할 수 있는 문제가 있었음.
현재 RxJava3를 데이터 스트림 전달에 사용하고 있었기 때문에 해당 값은 HomeScreen에서 `asFlow` 함수로 변환하여 사용함.
