### PR TITLE
[FIX] BVGraph 에러 수정 외

### DIFF
--- a/app/src/main/java/com/teamnoyes/balancevote/BVApp.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/BVApp.kt
@@ -25,7 +25,7 @@ fun BVApp() {
     ProvideWindowInsets {
         BalanceVoteTheme {
             val appState = rememberBVAppState()
-            val test = appState.test
+            val init = appState.init
             var turnTest = false
             Scaffold(
                 topBar = {

--- a/app/src/main/java/com/teamnoyes/balancevote/BVAppState.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/BVAppState.kt
@@ -22,17 +22,13 @@ fun rememberBVAppState(
 @Stable
 class BVAppState(val navController: NavHostController) {
 
-    init {
-
-    }
-
     val topUpToOffs = Screen.values()
     private val topUpToOffRoutes = topUpToOffs.map { it.route }
 
     val isNavigationOff: Boolean
         @Composable get() = navController.currentBackStackEntryAsState().value?.destination?.route in topUpToOffRoutes
 
-    val test: String?
+    val init: String?
         @Composable get() = navController.currentBackStackEntryAsState().value?.destination?.route
 
     val currentRoute: String?

--- a/app/src/main/java/com/teamnoyes/balancevote/data/api/BVService.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/data/api/BVService.kt
@@ -11,6 +11,6 @@ interface BVService {
     fun getAllVotePost(
         @Query("page") page: Int = 0,
         @Query("size") size: Int = 20,
-        @Query("sortBy") sortBy: String = "writer-asc",
+        @Query("sort") sort: String = "id,desc",
     ): Single<AllVotePostResponse>
 }

--- a/app/src/main/java/com/teamnoyes/balancevote/data/datasource/VotePostPagingSource.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/data/datasource/VotePostPagingSource.kt
@@ -27,7 +27,7 @@ class VotePostPagingSource @Inject constructor(private val api: BVService) :
 //        이 값이 계속 null이 나와서 같은 값이 반복됨
         val nextPageNumber = params.key ?: 0
 
-        return api.getAllVotePost(params.key ?: 0, 10, "writer-asc").subscribeOn(Schedulers.io())
+        return api.getAllVotePost(params.key ?: 0, 20, "id,desc").subscribeOn(Schedulers.io())
             .map { result -> LoadResult.Page(data = result.content, null, nextPageNumber+1) }
     }
 

--- a/app/src/main/java/com/teamnoyes/balancevote/data/datasource/VotePostPagingSource.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/data/datasource/VotePostPagingSource.kt
@@ -14,24 +14,16 @@ class VotePostPagingSource @Inject constructor(private val api: BVService) :
     RxPagingSource<Int, VotePost>() {
     override fun getRefreshKey(state: PagingState<Int, VotePost>): Int? {
 //        수정 필요
-        println(1)
         val anchorPosition = state.anchorPosition ?: return null
-        println(2)
         val anchorPage = state.closestPageToPosition(anchorPosition) ?: return null
-        println(3)
         val prevKey = anchorPage.prevKey
-        println(4)
         if (prevKey != null) return prevKey + 1
-        println(5)
         val nextKey = anchorPage.nextKey
-        println(6)
         if (nextKey != null) return nextKey - 1
-        println(7)
         return null
     }
 
     override fun loadSingle(params: LoadParams<Int>): Single<LoadResult<Int, VotePost>> {
-        println(1000)
 //        이 값이 계속 null이 나와서 같은 값이 반복됨
         val nextPageNumber = params.key ?: 0
 

--- a/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/home/HomeScreen.kt
@@ -36,14 +36,14 @@ import kotlinx.coroutines.reactive.asFlow
 @Composable
 fun HomeScreen(homeViewModel: HomeViewModel = viewModel()) {
     val allVotePostList = remember { mutableStateOf(homeViewModel.getPaging()) }
-    HomeScreenBody(pager = allVotePostList.value, bottomNavPadding = PaddingValues(bottom = 48.dp))
+    HomeScreenBody(pager = allVotePostList.value)
 }
 
 @OptIn(ExperimentalPagerApi::class, ExperimentalFoundationApi::class)
 @Composable
-fun HomeScreenBody(pager: Flowable<PagingData<VotePost>>, bottomNavPadding: PaddingValues) {
+fun HomeScreenBody(pager: Flowable<PagingData<VotePost>>) {
     val lazyPagingItems = pager.asFlow().collectAsLazyPagingItems()
-    Box(modifier = Modifier.padding(bottomNavPadding)) {
+    Box() {
         LazyColumn(modifier = Modifier) {
             items(count = 1) {
                 val pagerState = rememberPagerState()

--- a/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/post/PostScreen.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/post/PostScreen.kt
@@ -1,7 +1,6 @@
 package com.teamnoyes.balancevote.presentation.ui.screens.post
 
 import androidx.compose.foundation.layout.*
-import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment

--- a/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/post/PostScreen.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/post/PostScreen.kt
@@ -14,7 +14,7 @@ import com.teamnoyes.balancevote.presentation.ui.widget.*
 
 @Composable
 fun PostScreen() {
-    Box(modifier = Modifier.padding(bottom = 48.dp)) {
+    Box() {
         Column(modifier = Modifier
             .padding(16.dp)
             .fillMaxSize()) {

--- a/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/settings/SettingsScreen.kt
@@ -5,16 +5,12 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.core.content.ContextCompat.startActivity
 import com.google.android.gms.oss.licenses.OssLicensesMenuActivity
-import com.teamnoyes.balancevote.presentation.ui.widget.BVAppBar
-import com.teamnoyes.balancevote.presentation.ui.widget.BVBottomNavigation
 import com.teamnoyes.balancevote.presentation.ui.widget.BVTextButton
 
 @Composable

--- a/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/splash/SplashScreen.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/splash/SplashScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
-import androidx.compose.material.Scaffold
 import androidx.compose.material.Surface
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Home
@@ -18,14 +17,7 @@ import androidx.compose.ui.unit.dp
 import com.teamnoyes.balancevote.presentation.ui.theme.BalanceVoteTheme
 
 @Composable
-fun SplashScreen() {
-    Scaffold {
-        SplashBody()
-    }
-}
-
-@Composable
-fun SplashBody(
+fun SplashScreen(
     modifier: Modifier = Modifier
 ) {
     Box(

--- a/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/vote/VoteScreen.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/vote/VoteScreen.kt
@@ -1,7 +1,6 @@
 package com.teamnoyes.balancevote.presentation.ui.screens.vote
 
 import androidx.compose.foundation.layout.*
-import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -14,20 +13,10 @@ import com.teamnoyes.balancevote.presentation.ui.widget.BVTextButton
 import com.teamnoyes.balancevote.presentation.ui.widget.BVTextButtonRole
 
 @Composable
-fun VoteScreen() {
-    Scaffold() {
-        VoteBody(
-            leftTopic = "LEFT",
-            rightTopic = "RIGHT",
-        )
-    }
-}
-
-@Composable
-fun VoteBody(
+fun VoteScreen(
     modifier: Modifier = Modifier,
-    leftTopic: String,
-    rightTopic: String
+    leftTopic: String = "LEFT",
+    rightTopic: String = "RIGHT"
 ) {
     Column(
         modifier = modifier

--- a/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/widget/BVGraph.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/widget/BVGraph.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.graphics.Paint
 import androidx.compose.ui.graphics.PaintingStyle
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -34,6 +35,8 @@ fun BVGraph(
     vote2: Int = 0,
 ) {
 //    vote의 source는 viewModel일 것이므로 별도의 상태 복원 처리는 하지 않음
+    val confinguration = LocalConfiguration.current
+    val screenWidth = confinguration.screenWidthDp
     var voteRed = vote1.toFloat()
     var voteBlue = vote2.toFloat()
 //    둘 다 실제 값이 0일 수도 있으니까 값 입력 안 받으면 랜덤 표시는 문제가 있음. 별도의 인자 사용
@@ -61,14 +64,14 @@ fun BVGraph(
                 val paintRed = Paint()
                 paintRed.apply {
                     color = Color.Red
-                    strokeWidth = 108F
+                    strokeWidth = screenWidth/8F
                     style = PaintingStyle.Stroke
                     strokeCap = StrokeCap.Round
                 }
                 val paintBlue = Paint()
                 paintBlue.apply {
                     color = Color.Blue
-                    strokeWidth = 108F
+                    strokeWidth = screenWidth/8F
                     style = PaintingStyle.Stroke
                     strokeCap = StrokeCap.Round
                 }


### PR DESCRIPTION
# 관련 Issue
 * closes #31 

# 요약

## BVGraph 수정
- BVGraph의 호 두께(strokeWidth)가 화면의 너비의 비율에 맞게 조절되도록 함
```kotlin
val confinguration = LocalConfiguration.current
val screenWidth = confinguration.screenWidthDp

paintRed.apply {
                    color = Color.Red
                    strokeWidth = screenWidth/8F
                    style = PaintingStyle.Stroke
                    strokeCap = StrokeCap.Round
}
```

## 각 Screen에서 중복된 Padding, Scaffold 제거
- BVApp에서 이미 Scaffold가 구성되어 있고, 각 Screen들은 Scaffold에서 상단 Appbar와 하단 BottomNavigation 높이가 Padding으로 처리된 후의 공간을 차지하기 때문에 추가적으로 Padding을 적용할 필요가 없음
(하단 BVApp.kt 확인)
```kotlin
            Scaffold(
                topBar = {
                    BVAppBar(
                        title = appState.currentRoute?.uppercase() ?: "",
                        isNavigationOn = !appState.isNavigationOff
                    )
                },
                bottomBar = {
                    if (turnTest) {
                        BVBottomNavigation(
                            currentRoute = appState.currentRoute ?: "",
                            navigateToRoute = appState::navigateBottomNav
                        )
                    }
                }
            ) { pv ->
//                화면의 중간, 내용 부분
                NavHost(
                    navController = appState.navController,
                    startDestination = BVDestinations.HOME,
                    modifier = Modifier.padding(pv)
                ) {
//                    bvNavGraph(upPress = {})
                    addHomeGraph()
                    turnTest = true
                }
            }
``` 
이미 Scaffold가 구성되어있고, Scaffold 내부의 content에 해당하는 부분에 NavHost로 각 Screen이 놓이게 되는데, `modifier = Modifier.padding(pv)` 를 통해 Padding을 이미 계산하고 남은 부분에 Screen이 놓이게 된다는 것을 알 수 있음

