### PR TITLE
[FEAT] HomeScreen Hot Votes API 연동

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -101,5 +101,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.0"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-rx3:1.6.0"
 
+    implementation "androidx.compose.runtime:runtime-rxjava3:1.1.1"
+
 
 }

--- a/app/src/main/java/com/teamnoyes/balancevote/data/api/BVService.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/data/api/BVService.kt
@@ -1,5 +1,6 @@
 package com.teamnoyes.balancevote.data.api
 
+import com.teamnoyes.balancevote.data.model.VotePost
 import com.teamnoyes.balancevote.data.response.AllVotePostResponse
 import io.reactivex.rxjava3.core.Single
 import retrofit2.http.GET
@@ -13,4 +14,10 @@ interface BVService {
         @Query("size") size: Int = 20,
         @Query("sort") sort: String = "id,desc",
     ): Single<AllVotePostResponse>
+
+    @GET("/post/most-commented")
+    fun getMostCommentedPost(): Single<VotePost>
+
+    @GET("/post/most-voted")
+    fun getMostVotedPost(@Query("count") count: Int = 1): Single<List<VotePost>>
 }

--- a/app/src/main/java/com/teamnoyes/balancevote/data/datasource/RemoteVotePostDataSource.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/data/datasource/RemoteVotePostDataSource.kt
@@ -7,5 +7,7 @@ import javax.inject.Singleton
 @Singleton
 class RemoteVotePostDataSource @Inject constructor(private val api: BVService) {
 
-    fun getAllVotePost() = api.getAllVotePost()
+    fun getMostCommentedPost() = api.getMostCommentedPost()
+
+    fun getMostVotedPost() = api.getMostVotedPost()
 }

--- a/app/src/main/java/com/teamnoyes/balancevote/data/repository/VotePostRepository.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/data/repository/VotePostRepository.kt
@@ -11,8 +11,9 @@ class VotePostRepository @Inject constructor(
     private val remoteVotePostDataSource: RemoteVotePostDataSource,
     private val votePostPagingSource: VotePostPagingSource,
 ) {
+    fun getMostCommentedPost() = remoteVotePostDataSource.getMostCommentedPost()
 
-    fun getAllVotePost() = remoteVotePostDataSource.getAllVotePost()
+    fun getMostVotedPost() = remoteVotePostDataSource.getMostVotedPost()
 
     fun paging() = Pager(config = PagingConfig(pageSize = 20), pagingSourceFactory = { votePostPagingSource }).flowable
 }

--- a/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/home/HomeViewModel.kt
@@ -7,8 +7,10 @@ import androidx.paging.rxjava3.cachedIn
 import com.teamnoyes.balancevote.data.model.VotePost
 import com.teamnoyes.balancevote.data.repository.VotePostRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.core.Flowable
-import io.reactivex.rxjava3.disposables.CompositeDisposable
+import io.reactivex.rxjava3.core.Single
+import io.reactivex.rxjava3.schedulers.Schedulers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import javax.inject.Inject
 
@@ -17,29 +19,18 @@ class HomeViewModel @Inject constructor(
     private val votePostRepository: VotePostRepository,
 ) : ViewModel() {
 
-    private val disposable = CompositeDisposable()
+    val mostVotedPost: Single<VotePost> =
+        votePostRepository.getMostVotedPost().map { it.first() }.subscribeOn(Schedulers.io())
+            .observeOn(AndroidSchedulers.mainThread())
 
-//    Single은 이후에 Hot Votes에 사용하는 것으로
-//    fun getAllVotePost() {
-//        disposable.add(votePostRepository.getAllVotePost()
-//            .subscribeOn(Schedulers.newThread())
-//            .observeOn(AndroidSchedulers.mainThread())
-//            .subscribeWith(object : DisposableSingleObserver<AllVotePostResponse>() {
-//                override fun onSuccess(t: AllVotePostResponse) {
-//                    println(t)
-//                }
-//
-//                override fun onError(e: Throwable) {
-//                    Log.d(TAG, e.stackTraceToString())
-//                }
-//            }))
-//    }
+    val mostCommentedPost: Single<VotePost> =
+        votePostRepository.getMostCommentedPost().subscribeOn(Schedulers.io())
+            .observeOn(AndroidSchedulers.mainThread())
 
     @OptIn(ExperimentalCoroutinesApi::class)
     fun getPaging(): Flowable<PagingData<VotePost>> {
         return votePostRepository.paging().cachedIn(viewModelScope)
     }
-
 
     companion object {
         const val TAG = "HomeViewModel"

--- a/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/widget/BVGraph.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/widget/BVGraph.kt
@@ -50,8 +50,9 @@ fun BVGraph(
             voteRed = 1F
             voteBlue = 1F
         } else {
+            val temp = voteRed
             voteRed = voteRed / (voteRed + voteBlue) * 320
-            voteBlue = voteBlue / (voteRed + voteBlue) * 320
+            voteBlue = voteBlue / (temp + voteBlue) * 320
         }
     }
 //    box로 text와 겹치게 해보자

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <resources>
     <string name="app_name">BalanceVote</string>
-    <string name="home_card_type">Most Voted Topic</string>
+    <string name="home_hot_most_voted">Most Voted Topic</string>
+    <string name="home_hot_most_commented">Most Commented Topic</string>
     <string name="bv_text_field_empty">Can\'t post empty text</string>
 
     // EntryScreen


### PR DESCRIPTION
# 연관 issue
 * closes #38 

# 내용 요약

## BVGraph 버그 수정
- 그래프 비율이 정상적으로 해결되지 않던 에러 수정

## HomeScreen의 Hot Votes 관련 API 연동

### HomeViewModel
```kotlin
    val mostVotedPost: Single<VotePost> =
        votePostRepository.getMostVotedPost().map { it.first() }.subscribeOn(Schedulers.io())
            .observeOn(AndroidSchedulers.mainThread())

    val mostCommentedPost: Single<VotePost> =
        votePostRepository.getMostCommentedPost().subscribeOn(Schedulers.io())
            .observeOn(AndroidSchedulers.mainThread())
```
- MostVotedPost의 Response는 배열의 원소가 하나인 JSON 형태이기 때문에 `map` 함수로 배열의 첫 번째 값만 받아오도록 변환함

### HomeScreen
```kotlin
    val mostVoted = homeViewModel.mostVotedPost.subscribeAsState(initial = VotePost(
        0L,
        "",
        "",
        "",
        "",
        1,
        1))
    val mostCommented = homeViewModel.mostCommentedPost.subscribeAsState(initial = VotePost(
        0L,
        "",
        "",
        "",
        "",
        1,
        1))
```
- HomeScreen에서는 `subscribeAsState()` 함수를 통해 Single 객체를 이를 Composable의 관찰 가능한 State로 변환. 이를 위해 앱 모듈의 build.gradle에서 dependency 추가 ([참고](https://developer.android.com/reference/kotlin/androidx/compose/runtime/rxjava3/package-summary?hl=ko))
- 추후 개선 사항: VotePost에 대한 UiState를 추가하여 위와 같이 기본값 설정이 아닌 `isLoading` 등의 파라미터를 가지도록 하여 더욱 적절히 처리할 수 있도록 할 수 있을 것으로 예상됨

# 스크린샷
<img src="https://user-images.githubusercontent.com/37128456/162118971-8dc2176f-5636-4ec3-9e56-c51ca8911b3a.png" width="400" />