### PR TITLE
[FEAT] PostScreen API 연동

### DIFF
--- a/app/src/main/java/com/teamnoyes/balancevote/BVApp.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/BVApp.kt
@@ -2,9 +2,12 @@ package com.teamnoyes.balancevote
 
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Scaffold
+import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -20,6 +23,7 @@ import com.teamnoyes.balancevote.presentation.ui.theme.BalanceVoteTheme
 import com.teamnoyes.balancevote.presentation.ui.widget.BVAppBar
 import com.teamnoyes.balancevote.presentation.ui.widget.BVBottomNavigation
 import com.teamnoyes.balancevote.presentation.ui.widget.Screen
+import kotlinx.coroutines.launch
 
 @Composable
 fun BVApp() {
@@ -28,7 +32,10 @@ fun BVApp() {
             val appState = rememberBVAppState()
             val init = appState.init
             var turnTest = false
+            val scaffoldState = rememberScaffoldState()
+            val scope = rememberCoroutineScope()
             Scaffold(
+                scaffoldState = scaffoldState,
                 topBar = {
                     BVAppBar(
                         title = appState.currentRoute?.uppercase() ?: "",
@@ -51,7 +58,12 @@ fun BVApp() {
                     modifier = Modifier.padding(pv)
                 ) {
 //                    bvNavGraph(upPress = {})
-                    addHomeGraph()
+                    addHomeGraph(appState.navController) { msg ->
+                        scope.launch {
+                            scaffoldState.snackbarHostState
+                                .showSnackbar(msg)
+                        }
+                    }
                     turnTest = true
                 }
             }
@@ -59,14 +71,14 @@ fun BVApp() {
     }
 }
 
-fun NavGraphBuilder.addHomeGraph() {
+fun NavGraphBuilder.addHomeGraph(navController: NavController, snackbarEvent: (String) -> Unit) {
     composable(Screen.HOME.route) {
         val homeViewModel = hiltViewModel<HomeViewModel>()
         HomeScreen(homeViewModel)
     }
     composable(Screen.POST.route) {
         val postViewModel = hiltViewModel<PostViewModel>()
-        PostScreen(postViewModel)
+        PostScreen(postViewModel, navController, snackbarEvent)
     }
     composable(Screen.SETTINGS.route) { SettingsScreen() }
 }

--- a/app/src/main/java/com/teamnoyes/balancevote/BVApp.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/BVApp.kt
@@ -13,6 +13,7 @@ import com.google.accompanist.insets.ProvideWindowInsets
 import com.teamnoyes.balancevote.presentation.ui.screens.home.HomeScreen
 import com.teamnoyes.balancevote.presentation.ui.screens.home.HomeViewModel
 import com.teamnoyes.balancevote.presentation.ui.screens.post.PostScreen
+import com.teamnoyes.balancevote.presentation.ui.screens.post.PostViewModel
 import com.teamnoyes.balancevote.presentation.ui.screens.settings.SettingsScreen
 import com.teamnoyes.balancevote.presentation.ui.screens.vote.VoteScreen
 import com.teamnoyes.balancevote.presentation.ui.theme.BalanceVoteTheme
@@ -63,7 +64,10 @@ fun NavGraphBuilder.addHomeGraph() {
         val homeViewModel = hiltViewModel<HomeViewModel>()
         HomeScreen(homeViewModel)
     }
-    composable(Screen.POST.route) { PostScreen() }
+    composable(Screen.POST.route) {
+        val postViewModel = hiltViewModel<PostViewModel>()
+        PostScreen(postViewModel)
+    }
     composable(Screen.SETTINGS.route) { SettingsScreen() }
 }
 

--- a/app/src/main/java/com/teamnoyes/balancevote/data/api/BVService.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/data/api/BVService.kt
@@ -25,5 +25,5 @@ interface BVService {
     fun getMostVotedPost(@Query("count") count: Int = 1): Single<List<VotePost>>
 
     @POST("/post/vote-post")
-    fun postNewVote(@Body postNewVoteRequest: PostNewVoteRequest): Single<String>
+    fun postNewVote(@Body postNewVoteRequest: PostNewVoteRequest): Single<VotePost>
 }

--- a/app/src/main/java/com/teamnoyes/balancevote/data/api/BVService.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/data/api/BVService.kt
@@ -1,9 +1,12 @@
 package com.teamnoyes.balancevote.data.api
 
 import com.teamnoyes.balancevote.data.model.VotePost
+import com.teamnoyes.balancevote.data.request.PostNewVoteRequest
 import com.teamnoyes.balancevote.data.response.AllVotePostResponse
 import io.reactivex.rxjava3.core.Single
+import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.POST
 import retrofit2.http.Query
 
 interface BVService {
@@ -20,4 +23,7 @@ interface BVService {
 
     @GET("/post/most-voted")
     fun getMostVotedPost(@Query("count") count: Int = 1): Single<List<VotePost>>
+
+    @POST("/post/vote-post")
+    fun postNewVote(@Body postNewVoteRequest: PostNewVoteRequest): Single<String>
 }

--- a/app/src/main/java/com/teamnoyes/balancevote/data/datasource/RemoteVotePostDataSource.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/data/datasource/RemoteVotePostDataSource.kt
@@ -1,6 +1,7 @@
 package com.teamnoyes.balancevote.data.datasource
 
 import com.teamnoyes.balancevote.data.api.BVService
+import com.teamnoyes.balancevote.data.request.PostNewVoteRequest
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -10,4 +11,7 @@ class RemoteVotePostDataSource @Inject constructor(private val api: BVService) {
     fun getMostCommentedPost() = api.getMostCommentedPost()
 
     fun getMostVotedPost() = api.getMostVotedPost()
+
+    fun postNewVote(selectionOne: String, selectionTwo: String, uuid: String) =
+        api.postNewVote(PostNewVoteRequest(selectionOne, selectionTwo, uuid))
 }

--- a/app/src/main/java/com/teamnoyes/balancevote/data/repository/VotePostRepository.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/data/repository/VotePostRepository.kt
@@ -15,5 +15,9 @@ class VotePostRepository @Inject constructor(
 
     fun getMostVotedPost() = remoteVotePostDataSource.getMostVotedPost()
 
-    fun paging() = Pager(config = PagingConfig(pageSize = 20), pagingSourceFactory = { votePostPagingSource }).flowable
+    fun paging() = Pager(config = PagingConfig(pageSize = 20),
+        pagingSourceFactory = { votePostPagingSource }).flowable
+
+    fun postNewPost(selectionOne: String, selectionTwo: String, uuid: String) =
+        remoteVotePostDataSource.postNewVote(selectionOne, selectionTwo, uuid)
 }

--- a/app/src/main/java/com/teamnoyes/balancevote/data/request/PostNewVoteRequest.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/data/request/PostNewVoteRequest.kt
@@ -1,0 +1,6 @@
+package com.teamnoyes.balancevote.data.request
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class PostNewVoteRequest(val selectionOne: String, val selectionTwo: String, val uuid: String)

--- a/app/src/main/java/com/teamnoyes/balancevote/data/response/PostNewVoteResponse.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/data/response/PostNewVoteResponse.kt
@@ -1,0 +1,6 @@
+package com.teamnoyes.balancevote.data.response
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class PostNewVoteResponse(val votePostId: String)

--- a/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/entry/EntryScreen.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/entry/EntryScreen.kt
@@ -63,7 +63,8 @@ fun EntryBody(
         ) {
             BVInput(
                 enableButton = false,
-                hintMessage = stringResource(id = R.string.entry_hint_nickname)
+                hintMessage = stringResource(id = R.string.entry_hint_nickname),
+                onTextChanged = {}
             )
 
             BVTextButton(

--- a/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/home/HomeScreen.kt
@@ -79,10 +79,12 @@ fun HomeScreenBody(
                 ) {
                     when (this.currentPage) {
                         0 -> {
-                            HotVotesItem(mostVoted, stringResource(id = R.string.home_hot_most_voted))
+                            HotVotesItem(mostVoted,
+                                stringResource(id = R.string.home_hot_most_voted))
                         }
                         1 -> {
-                            HotVotesItem(mostCommented, stringResource(id = R.string.home_hot_most_commented))
+                            HotVotesItem(mostCommented,
+                                stringResource(id = R.string.home_hot_most_commented))
                         }
                     }
                 }

--- a/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/post/PostScreen.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/post/PostScreen.kt
@@ -3,17 +3,37 @@ package com.teamnoyes.balancevote.presentation.ui.screens.post
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.teamnoyes.balancevote.presentation.ui.widget.*
 
 @Composable
-fun PostScreen() {
+fun PostScreen(viewModel: PostViewModel = viewModel()) {
+    val a = remember { mutableStateOf("") }
+    val b = remember { mutableStateOf("") }
+    PostScreenBody(onSelectionOneChanged = { a.value = it.text },
+        onSelectionTwoChanged = { b.value = it.text }) {
+        println(a.value)
+        println(b.value)
+        viewModel.postNewVote(a.value, b.value, "0419Test")
+    }
+}
+
+@Composable
+fun PostScreenBody(
+    onSelectionOneChanged: (TextFieldValue) -> Unit,
+    onSelectionTwoChanged: (TextFieldValue) -> Unit,
+    onPostVote: () -> Unit
+) {
     Box() {
         Column(modifier = Modifier
             .padding(16.dp)
@@ -21,7 +41,8 @@ fun PostScreen() {
             BVInput(
                 enableButton = false,
                 hintMessage = "1",
-                keyboardAction = ImeAction.Next
+                keyboardAction = ImeAction.Next,
+                onTextChanged = {onSelectionOneChanged(it)}
             )
             Text(
                 text = "VS",
@@ -37,6 +58,7 @@ fun PostScreen() {
                 enableButton = false,
                 hintMessage = "2",
                 keyboardAction = ImeAction.Send,
+                onTextChanged = {onSelectionTwoChanged(it)},
                 onSendButtonClick = {}
             )
             Column(
@@ -45,7 +67,7 @@ fun PostScreen() {
                     .wrapContentSize(Alignment.BottomCenter)) {
                 BVTextButton(
                     text = "POST",
-                    onClick = {},
+                    onClick = onPostVote,
                     isSelected = false
                 )
             }
@@ -53,8 +75,8 @@ fun PostScreen() {
     }
 }
 
-@Preview
+@Preview(showBackground = true, showSystemUi = true)
 @Composable
 fun PreviewPostScreen() {
-    PostScreen()
+    PostScreenBody({}, {}, {})
 }

--- a/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/post/PostScreen.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/post/PostScreen.kt
@@ -14,16 +14,30 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.navigation.NavController
 import com.teamnoyes.balancevote.presentation.ui.widget.*
 
+data class PostNewVoteUiState(val isPosted: Boolean = false, val throwError: Boolean = false)
+
 @Composable
-fun PostScreen(viewModel: PostViewModel = viewModel()) {
+fun PostScreen(
+    viewModel: PostViewModel = viewModel(),
+    navController: NavController,
+    snackbarEvent: (String) -> Unit,
+) {
     val a = remember { mutableStateOf("") }
     val b = remember { mutableStateOf("") }
+    if (viewModel.postNewVoteUiState.value.isPosted) {
+        snackbarEvent("Success")
+        viewModel.postNewVoteUiState.value = PostNewVoteUiState(isPosted = false)
+        navController.navigate(Screen.HOME.route)
+    }
+    if (viewModel.postNewVoteUiState.value.throwError) {
+        snackbarEvent("Fail")
+        viewModel.postNewVoteUiState.value = PostNewVoteUiState(throwError = false)
+    }
     PostScreenBody(onSelectionOneChanged = { a.value = it.text },
         onSelectionTwoChanged = { b.value = it.text }) {
-        println(a.value)
-        println(b.value)
         viewModel.postNewVote(a.value, b.value, "0419Test")
     }
 }
@@ -32,7 +46,7 @@ fun PostScreen(viewModel: PostViewModel = viewModel()) {
 fun PostScreenBody(
     onSelectionOneChanged: (TextFieldValue) -> Unit,
     onSelectionTwoChanged: (TextFieldValue) -> Unit,
-    onPostVote: () -> Unit
+    onPostVote: () -> Unit,
 ) {
     Box() {
         Column(modifier = Modifier
@@ -42,7 +56,7 @@ fun PostScreenBody(
                 enableButton = false,
                 hintMessage = "1",
                 keyboardAction = ImeAction.Next,
-                onTextChanged = {onSelectionOneChanged(it)}
+                onTextChanged = { onSelectionOneChanged(it) }
             )
             Text(
                 text = "VS",
@@ -58,7 +72,7 @@ fun PostScreenBody(
                 enableButton = false,
                 hintMessage = "2",
                 keyboardAction = ImeAction.Send,
-                onTextChanged = {onSelectionTwoChanged(it)},
+                onTextChanged = { onSelectionTwoChanged(it) },
                 onSendButtonClick = {}
             )
             Column(

--- a/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/post/PostViewModel.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/post/PostViewModel.kt
@@ -1,7 +1,9 @@
 package com.teamnoyes.balancevote.presentation.ui.screens.post
 
 import android.util.Log
+import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
+import com.teamnoyes.balancevote.data.model.VotePost
 import com.teamnoyes.balancevote.data.repository.VotePostRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
@@ -14,18 +16,21 @@ import javax.inject.Inject
 class PostViewModel @Inject constructor(private val repository: VotePostRepository) : ViewModel() {
 
     private val disposable = CompositeDisposable()
+    val postNewVoteUiState = mutableStateOf(PostNewVoteUiState())
 
     fun postNewVote(selectionOne: String, selectionTwo: String, uuid: String) {
         disposable.add(repository.postNewPost(selectionOne, selectionTwo, uuid)
             .subscribeOn(Schedulers.newThread())
             .observeOn(AndroidSchedulers.mainThread())
-            .subscribeWith(object : DisposableSingleObserver<String>() {
-                override fun onSuccess(t: String) {
-                    println(t)
+            .subscribeWith(object : DisposableSingleObserver<VotePost>() {
+                override fun onSuccess(t: VotePost) {
+                    Log.d(TAG, t.toString())
+                    postNewVoteUiState.value = PostNewVoteUiState(isPosted = true)
                 }
 
                 override fun onError(e: Throwable) {
                     Log.d(TAG, e.stackTraceToString())
+                    postNewVoteUiState.value = PostNewVoteUiState(throwError = true)
                 }
             }))
     }

--- a/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/post/PostViewModel.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/post/PostViewModel.kt
@@ -1,4 +1,41 @@
 package com.teamnoyes.balancevote.presentation.ui.screens.post
 
-class PostViewModel {
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import com.teamnoyes.balancevote.data.repository.VotePostRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
+import io.reactivex.rxjava3.disposables.CompositeDisposable
+import io.reactivex.rxjava3.observers.DisposableSingleObserver
+import io.reactivex.rxjava3.schedulers.Schedulers
+import javax.inject.Inject
+
+@HiltViewModel
+class PostViewModel @Inject constructor(private val repository: VotePostRepository) : ViewModel() {
+
+    private val disposable = CompositeDisposable()
+
+    fun postNewVote(selectionOne: String, selectionTwo: String, uuid: String) {
+        disposable.add(repository.postNewPost(selectionOne, selectionTwo, uuid)
+            .subscribeOn(Schedulers.newThread())
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribeWith(object : DisposableSingleObserver<String>() {
+                override fun onSuccess(t: String) {
+                    println(t)
+                }
+
+                override fun onError(e: Throwable) {
+                    Log.d(TAG, e.stackTraceToString())
+                }
+            }))
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        disposable.clear()
+    }
+
+    companion object {
+        const val TAG = "PostViewModel"
+    }
 }

--- a/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/vote/detail/DetailVoteScreen.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/vote/detail/DetailVoteScreen.kt
@@ -33,7 +33,8 @@ fun DetailVoteScreen() {
         ) {
             BVInput(
                 enableButton = true,
-                hintMessage = stringResource(id = R.string.detail_vote_hint)
+                hintMessage = stringResource(id = R.string.detail_vote_hint),
+                onTextChanged = {}
             )
         }
     }

--- a/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/widget/BVTextField.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/widget/BVTextField.kt
@@ -42,12 +42,13 @@ fun BVInput(
     enableButton: Boolean,
     hintMessage: String,
     keyboardAction: ImeAction = ImeAction.Send,
+    onTextChanged: (TextFieldValue) -> Unit,
     onSendButtonClick: (String) -> Unit = {},
 ) {
     var textState by remember { mutableStateOf(TextFieldValue()) }
     val focusRequester = remember { FocusRequester() }
     val focusManager = LocalFocusManager.current
-    val isFirst = remember { mutableStateOf(true)}
+    val isFirst = remember { mutableStateOf(true) }
 
     Column() {
         Row(
@@ -67,6 +68,7 @@ fun BVInput(
                     onTextChanged = {
                         textState = it
                         isFirst.value = false
+                        onTextChanged(it)
                     },
                     onSendButtonClick = {
                         onSendButtonClick(it.text)
@@ -178,7 +180,10 @@ fun PreviewTextFieldWithButton() {
             modifier = Modifier.fillMaxWidth(),
             color = MaterialTheme.colors.background
         ) {
-            BVInput(enableButton = true, hintMessage = "Another Hint String Test", keyboardAction = ImeAction.Send) {}
+            BVInput(enableButton = true,
+                hintMessage = "Another Hint String Test",
+                keyboardAction = ImeAction.Send,
+                onTextChanged = {}) {}
         }
     }
 }
@@ -191,7 +196,10 @@ fun PreviewTextFieldWithoutButton() {
             modifier = Modifier.fillMaxWidth(),
             color = MaterialTheme.colors.background
         ) {
-            BVInput(enableButton = false, hintMessage = "힌트 문자열 테스트", keyboardAction = ImeAction.Send) {}
+            BVInput(enableButton = false,
+                hintMessage = "힌트 문자열 테스트",
+                keyboardAction = ImeAction.Send,
+                onTextChanged = {}) {}
         }
     }
 }


### PR DESCRIPTION
# 관련 Issue
 * closes #44

# 주요 내용

## PostNewVote API response type 변경
- 기존 반환 타입이 JSON 형식을 지키지 않아 에러가 발생했음(malformed). 서버에 요청하여 수정되었고, 반환 타입은 VotePost로 수정됨

## PostNewVote API 결과에 따른 Snackbar 표시
- PostNewVote 결과를 알리기 위해 결과를 알리기 위한 UiState를 만들고, ViewModel이 State 내에 표시

```kotlin
class PostViewModel @Inject constructor(private val repository: VotePostRepository) : ViewModel() {

    private val disposable = CompositeDisposable()
    val postNewVoteUiState = mutableStateOf(PostNewVoteUiState())

    fun postNewVote(selectionOne: String, selectionTwo: String, uuid: String) {
        disposable.add(repository.postNewPost(selectionOne, selectionTwo, uuid)
            .subscribeOn(Schedulers.newThread())
            .observeOn(AndroidSchedulers.mainThread())
            .subscribeWith(object : DisposableSingleObserver<VotePost>() {
                override fun onSuccess(t: VotePost) {
                    Log.d(TAG, t.toString())
                    postNewVoteUiState.value = PostNewVoteUiState(isPosted = true)
                }

                override fun onError(e: Throwable) {
                    Log.d(TAG, e.stackTraceToString())
                    postNewVoteUiState.value = PostNewVoteUiState(throwError = true)
                }
            }))
    }
```

- PostScreen에서는 `postNewVoteUiState`의 변화에 따라 Snackbar 표시 이벤트를 상위 Composable에서 전달해준 Parameter를 통해 호출

```kotlin
@Composable
fun PostScreen(
    viewModel: PostViewModel = viewModel(),
    navController: NavController,
    snackbarEvent: (String) -> Unit,
) {
    if (viewModel.postNewVoteUiState.value.isPosted) {
        snackbarEvent("Success")
        viewModel.postNewVoteUiState.value = PostNewVoteUiState(isPosted = false)
        navController.navigate(Screen.HOME.route)
    }
    if (viewModel.postNewVoteUiState.value.throwError) {
        snackbarEvent("Fail")
        viewModel.postNewVoteUiState.value = PostNewVoteUiState(throwError = false)
    }
```

- 추가로 PostNewVote API 결과가 성공시, HomeScreen으로 이동하도록 상위 Composable에서 전달해준 Parameter를 호출


# 결과 영상
![postSuccess](https://user-images.githubusercontent.com/37128456/164890144-38d90f6d-59cd-4e14-a703-606fa0bfd25d.gif)