### PR TITLE
[FEAT] VoteScreen API 연동 및 기능 구현

### DIFF
--- a/app/src/main/java/com/teamnoyes/balancevote/BVApp.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/BVApp.kt
@@ -7,11 +7,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.navigation.NavController
-import androidx.navigation.NavGraphBuilder
+import androidx.navigation.*
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
-import androidx.navigation.navigation
 import com.google.accompanist.insets.ProvideWindowInsets
 import com.teamnoyes.balancevote.presentation.ui.screens.entry.EntryScreen
 import com.teamnoyes.balancevote.presentation.ui.screens.home.HomeScreen
@@ -84,7 +82,15 @@ fun NavGraphBuilder.addMainGraph(navController: NavController, snackbarEvent: (S
             val homeViewModel = hiltViewModel<HomeViewModel>()
             HomeScreen(homeViewModel, navController)
         }
-        composable(VotePostScreen.VOTE.route) { VoteScreen(navController = navController) }
+        composable(VotePostScreen.VOTE.route,
+            arguments = listOf(navArgument("id") { type = NavType.LongType },
+                navArgument("left") { type = NavType.StringType },
+                navArgument("right") { type = NavType.StringType })) {
+            VoteScreen(id = it.arguments?.getLong("id") ?: 0L,
+                leftTopic = it.arguments?.getString("left") ?: "",
+                rightTopic = it.arguments?.getString("right") ?: "",
+                navController = navController)
+        }
         composable(VotePostScreen.DETAIL.route) { DetailVoteScreen(navController) }
         composable(BottomNavScreen.POST.route) {
             val postViewModel = hiltViewModel<PostViewModel>()

--- a/app/src/main/java/com/teamnoyes/balancevote/BVApp.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/BVApp.kt
@@ -92,7 +92,8 @@ fun NavGraphBuilder.addMainGraph(navController: NavController, snackbarEvent: (S
                 postId = it.arguments?.getString("postId") ?: "",
                 leftTopic = it.arguments?.getString("left") ?: "",
                 rightTopic = it.arguments?.getString("right") ?: "",
-                navController = navController)
+                navController = navController,
+                snackbarEvent = snackbarEvent)
         }
         composable(VotePostScreen.DETAIL.route) { DetailVoteScreen(navController) }
         composable(BottomNavScreen.POST.route) {

--- a/app/src/main/java/com/teamnoyes/balancevote/BVApp.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/BVApp.kt
@@ -19,6 +19,7 @@ import com.teamnoyes.balancevote.presentation.ui.screens.post.PostViewModel
 import com.teamnoyes.balancevote.presentation.ui.screens.settings.SettingsScreen
 import com.teamnoyes.balancevote.presentation.ui.screens.splash.SplashScreen
 import com.teamnoyes.balancevote.presentation.ui.screens.vote.VoteScreen
+import com.teamnoyes.balancevote.presentation.ui.screens.vote.VoteViewModel
 import com.teamnoyes.balancevote.presentation.ui.screens.vote.detail.DetailVoteScreen
 import com.teamnoyes.balancevote.presentation.ui.theme.BalanceVoteTheme
 import com.teamnoyes.balancevote.presentation.ui.widget.BVAppBar
@@ -83,10 +84,12 @@ fun NavGraphBuilder.addMainGraph(navController: NavController, snackbarEvent: (S
             HomeScreen(homeViewModel, navController)
         }
         composable(VotePostScreen.VOTE.route,
-            arguments = listOf(navArgument("id") { type = NavType.LongType },
+            arguments = listOf(navArgument("postId") { type = NavType.StringType },
                 navArgument("left") { type = NavType.StringType },
                 navArgument("right") { type = NavType.StringType })) {
-            VoteScreen(id = it.arguments?.getLong("id") ?: 0L,
+            val voteViewModel = hiltViewModel<VoteViewModel>()
+            VoteScreen(viewModel = voteViewModel,
+                postId = it.arguments?.getString("postId") ?: "",
                 leftTopic = it.arguments?.getString("left") ?: "",
                 rightTopic = it.arguments?.getString("right") ?: "",
                 navController = navController)

--- a/app/src/main/java/com/teamnoyes/balancevote/BVAppState.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/BVAppState.kt
@@ -55,6 +55,6 @@ class BVAppState(val navController: NavHostController) {
 }
 
 enum class VotePostScreen(val title: String, val route: String) {
-    VOTE("VOTE", "main/vote"),
+    VOTE("VOTE", "main/vote/{id}/{left}/{right}"),
     DETAIL("DETAIL", "main/detail")
 }

--- a/app/src/main/java/com/teamnoyes/balancevote/BVAppState.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/BVAppState.kt
@@ -55,6 +55,6 @@ class BVAppState(val navController: NavHostController) {
 }
 
 enum class VotePostScreen(val title: String, val route: String) {
-    VOTE("VOTE", "main/vote/{id}/{left}/{right}"),
+    VOTE("VOTE", "main/vote/{postId}/{left}/{right}"),
     DETAIL("DETAIL", "main/detail")
 }

--- a/app/src/main/java/com/teamnoyes/balancevote/data/api/BVService.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/data/api/BVService.kt
@@ -2,6 +2,7 @@ package com.teamnoyes.balancevote.data.api
 
 import com.teamnoyes.balancevote.data.model.VotePost
 import com.teamnoyes.balancevote.data.request.PostNewVoteRequest
+import com.teamnoyes.balancevote.data.request.PostVoteSelection
 import com.teamnoyes.balancevote.data.response.AllVotePostResponse
 import io.reactivex.rxjava3.core.Single
 import retrofit2.http.Body
@@ -26,4 +27,7 @@ interface BVService {
 
     @POST("/post/vote-post")
     fun postNewVote(@Body postNewVoteRequest: PostNewVoteRequest): Single<VotePost>
+
+    @POST("/post/vote-post/{postId}")
+    fun postVoteSelection(@Query("postId") postId: String, @Body postVoteSelection: PostVoteSelection): Single<Boolean>
 }

--- a/app/src/main/java/com/teamnoyes/balancevote/data/datasource/RemoteVotePostDataSource.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/data/datasource/RemoteVotePostDataSource.kt
@@ -2,6 +2,7 @@ package com.teamnoyes.balancevote.data.datasource
 
 import com.teamnoyes.balancevote.data.api.BVService
 import com.teamnoyes.balancevote.data.request.PostNewVoteRequest
+import com.teamnoyes.balancevote.data.request.PostVoteSelection
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -14,4 +15,7 @@ class RemoteVotePostDataSource @Inject constructor(private val api: BVService) {
 
     fun postNewVote(selectionOne: String, selectionTwo: String, uuid: String) =
         api.postNewVote(PostNewVoteRequest(selectionOne, selectionTwo, uuid))
+
+    fun postVoteSelection(postId: String, selection: String, uuid: String) =
+        api.postVoteSelection(postId, PostVoteSelection(selection, uuid))
 }

--- a/app/src/main/java/com/teamnoyes/balancevote/data/repository/VotePostRepository.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/data/repository/VotePostRepository.kt
@@ -20,4 +20,7 @@ class VotePostRepository @Inject constructor(
 
     fun postNewPost(selectionOne: String, selectionTwo: String, uuid: String) =
         remoteVotePostDataSource.postNewVote(selectionOne, selectionTwo, uuid)
+
+    fun postVoteSelection(postId: String, selection: String, uuid: String) =
+        remoteVotePostDataSource.postVoteSelection(postId, selection, uuid)
 }

--- a/app/src/main/java/com/teamnoyes/balancevote/data/request/PostVoteSelection.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/data/request/PostVoteSelection.kt
@@ -1,0 +1,6 @@
+package com.teamnoyes.balancevote.data.request
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class PostVoteSelection(val selectedPos: String, val uuid: String)

--- a/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/home/HomeScreen.kt
@@ -42,7 +42,7 @@ fun HomeScreen(homeViewModel: HomeViewModel = viewModel(), navController: NavCon
     val mostVoted = homeViewModel.mostVotedPost.subscribeAsState(initial = VotePost())
     val mostCommented = homeViewModel.mostCommentedPost.subscribeAsState(initial = VotePost())
     HomeScreenBody(pager = allVotePostList.value, mostVoted.value, mostCommented.value) {
-        navController.navigate("main/vote")
+        navController.navigate("main/vote/${it.id}/${it.selectionOne}/${it.selectionTwo}")
     }
 }
 

--- a/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/home/HomeScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
 import androidx.paging.PagingData
 import androidx.paging.compose.collectAsLazyPagingItems
 import androidx.paging.compose.items
@@ -42,7 +43,7 @@ fun HomeScreen(homeViewModel: HomeViewModel = viewModel(), navController: NavCon
     val mostVoted = homeViewModel.mostVotedPost.subscribeAsState(initial = VotePost())
     val mostCommented = homeViewModel.mostCommentedPost.subscribeAsState(initial = VotePost())
     HomeScreenBody(pager = allVotePostList.value, mostVoted.value, mostCommented.value) {
-        navController.navigate("main/vote/${it.id}/${it.selectionOne}/${it.selectionTwo}")
+        navController.navigate("main/vote/${it.postId}/${it.selectionOne}/${it.selectionTwo}")
     }
 }
 
@@ -140,5 +141,5 @@ fun HotVotesItem(votePost: VotePost?, title: String) {
 @Preview(showBackground = true)
 @Composable
 fun PreviewHomeScreen() {
-//    HomeScreenBody(pager = , mostVoted = , mostCommented = , onVotePostClicked = )
+    HomeScreen(viewModel(), rememberNavController())
 }

--- a/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/home/HomeViewModel.kt
@@ -15,9 +15,8 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import javax.inject.Inject
 
 @HiltViewModel
-class HomeViewModel @Inject constructor(
-    private val votePostRepository: VotePostRepository,
-) : ViewModel() {
+class HomeViewModel @Inject constructor(private val votePostRepository: VotePostRepository) :
+    ViewModel() {
 
     val mostVotedPost: Single<VotePost> =
         votePostRepository.getMostVotedPost().map { it.first() }.subscribeOn(Schedulers.io())

--- a/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/vote/VoteScreen.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/vote/VoteScreen.kt
@@ -6,20 +6,25 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
 import com.teamnoyes.balancevote.presentation.ui.theme.BalanceVoteTheme
 import com.teamnoyes.balancevote.presentation.ui.widget.BVTextButton
 import com.teamnoyes.balancevote.presentation.ui.widget.BVTextButtonRole
 
+data class PostVoteSelectionUiState(val isPosted: Boolean = false, val throwError: Boolean = false)
+
 @Composable
 fun VoteScreen(
+    viewModel: VoteViewModel = viewModel(),
     modifier: Modifier = Modifier,
     navController: NavController,
-    id: Long,
+    postId: String,
     leftTopic: String = "LEFT",
-    rightTopic: String = "RIGHT"
+    rightTopic: String = "RIGHT",
 ) {
     Column(
         modifier = modifier
@@ -42,7 +47,7 @@ fun VoteScreen(
         Spacer(modifier = modifier.padding(0.dp, 12.dp))
         BVTextButton(
             text = leftTopic,
-            onClick = {},
+            onClick = {viewModel.postVoteSelection(postId, "1", "0530testUUID1000")},
             isSelected = false,
             role = BVTextButtonRole.RED,
             horizontalAlignment = Arrangement.Start,
@@ -52,7 +57,7 @@ fun VoteScreen(
         Spacer(modifier = modifier.padding(0.dp, 12.dp))
         BVTextButton(
             text = rightTopic,
-            onClick = {},
+            onClick = {viewModel.postVoteSelection(postId, "2", "0530testUUID1000")},
             isSelected = false,
             role = BVTextButtonRole.BLUE,
             horizontalAlignment = Arrangement.Start,
@@ -68,7 +73,10 @@ fun VoteScreenPreviewLight() {
     VoteScreenPreview(darkTheme = false)
 }
 
-@Preview(name = "VoteScreen Dark", showBackground = true, showSystemUi = true)
+@Preview(name = "VoteScreen Dark",
+    showBackground = true,
+    backgroundColor = 0x303030,
+    showSystemUi = true)
 @Composable
 fun VoteScreenPreviewDark() {
     VoteScreenPreview(darkTheme = true)
@@ -77,6 +85,6 @@ fun VoteScreenPreviewDark() {
 @Composable
 fun VoteScreenPreview(darkTheme: Boolean) {
     BalanceVoteTheme(darkTheme) {
-//        VoteScreen()
+        VoteScreen(postId = "", navController = rememberNavController())
     }
 }

--- a/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/vote/VoteScreen.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/vote/VoteScreen.kt
@@ -16,9 +16,10 @@ import com.teamnoyes.balancevote.presentation.ui.widget.BVTextButtonRole
 @Composable
 fun VoteScreen(
     modifier: Modifier = Modifier,
+    navController: NavController,
+    id: Long,
     leftTopic: String = "LEFT",
-    rightTopic: String = "RIGHT",
-    navController: NavController
+    rightTopic: String = "RIGHT"
 ) {
     Column(
         modifier = modifier

--- a/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/vote/VoteScreen.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/vote/VoteScreen.kt
@@ -11,9 +11,11 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
+import com.teamnoyes.balancevote.VotePostScreen
 import com.teamnoyes.balancevote.presentation.ui.theme.BalanceVoteTheme
 import com.teamnoyes.balancevote.presentation.ui.widget.BVTextButton
 import com.teamnoyes.balancevote.presentation.ui.widget.BVTextButtonRole
+import com.teamnoyes.balancevote.presentation.ui.widget.BottomNavScreen
 
 data class PostVoteSelectionUiState(val isPosted: Boolean = false, val throwError: Boolean = false)
 
@@ -22,9 +24,32 @@ fun VoteScreen(
     viewModel: VoteViewModel = viewModel(),
     modifier: Modifier = Modifier,
     navController: NavController,
+    snackbarEvent: (String) -> Unit,
     postId: String,
     leftTopic: String = "LEFT",
     rightTopic: String = "RIGHT",
+) {
+    if (viewModel.postVoteSelectionUiState.value.isPosted) {
+        snackbarEvent("Success")
+        viewModel.postVoteSelectionUiState.value = PostVoteSelectionUiState(isPosted = false)
+        navController.navigate(VotePostScreen.DETAIL.route) {
+            popUpTo(BottomNavScreen.HOME.route)
+        }
+    }
+    if (viewModel.postVoteSelectionUiState.value.throwError) {
+        snackbarEvent("Fail")
+        viewModel.postVoteSelectionUiState.value = PostVoteSelectionUiState(throwError = false)
+    }
+    VoteScreenBody(viewModel, modifier, postId, leftTopic, rightTopic)
+}
+
+@Composable
+fun VoteScreenBody(
+    viewModel: VoteViewModel = viewModel(),
+    modifier: Modifier = Modifier,
+    postId: String,
+    leftTopic: String,
+    rightTopic: String
 ) {
     Column(
         modifier = modifier
@@ -47,7 +72,7 @@ fun VoteScreen(
         Spacer(modifier = modifier.padding(0.dp, 12.dp))
         BVTextButton(
             text = leftTopic,
-            onClick = {viewModel.postVoteSelection(postId, "1", "0530testUUID1000")},
+            onClick = { viewModel.postVoteSelection(postId, "1", "0530testUUID1000") },
             isSelected = false,
             role = BVTextButtonRole.RED,
             horizontalAlignment = Arrangement.Start,
@@ -57,7 +82,7 @@ fun VoteScreen(
         Spacer(modifier = modifier.padding(0.dp, 12.dp))
         BVTextButton(
             text = rightTopic,
-            onClick = {viewModel.postVoteSelection(postId, "2", "0530testUUID1000")},
+            onClick = { viewModel.postVoteSelection(postId, "2", "0530testUUID1000") },
             isSelected = false,
             role = BVTextButtonRole.BLUE,
             horizontalAlignment = Arrangement.Start,
@@ -85,6 +110,6 @@ fun VoteScreenPreviewDark() {
 @Composable
 fun VoteScreenPreview(darkTheme: Boolean) {
     BalanceVoteTheme(darkTheme) {
-        VoteScreen(postId = "", navController = rememberNavController())
+        VoteScreenBody(postId = "", leftTopic = "LEFT", rightTopic = "RIGHT")
     }
 }

--- a/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/vote/VoteViewModel.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/vote/VoteViewModel.kt
@@ -1,4 +1,45 @@
 package com.teamnoyes.balancevote.presentation.ui.screens.vote
 
-class VoteViewModel {
+import android.util.Log
+import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.ViewModel
+import com.teamnoyes.balancevote.data.repository.VotePostRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
+import io.reactivex.rxjava3.disposables.CompositeDisposable
+import io.reactivex.rxjava3.observers.DisposableSingleObserver
+import io.reactivex.rxjava3.schedulers.Schedulers
+import javax.inject.Inject
+
+@HiltViewModel
+class VoteViewModel @Inject constructor(private val repository: VotePostRepository) :
+    ViewModel() {
+
+    private val disposable = CompositeDisposable()
+    val postVoteSelectionUiState = mutableStateOf(PostVoteSelectionUiState())
+
+    fun postVoteSelection(postId: String, selection: String, uuid: String) {
+        disposable.add(repository.postVoteSelection(postId, selection, uuid).subscribeOn(Schedulers.io())
+            .observeOn(AndroidSchedulers.mainThread()).subscribeWith(object : DisposableSingleObserver<Boolean>() {
+                override fun onSuccess(t: Boolean) {
+                    if(t) {
+                        Log.d(TAG, "PostVoteSelection Success: $t")
+                        postVoteSelectionUiState.value = PostVoteSelectionUiState(isPosted = true)
+                    } else {
+                        Log.d(TAG, "PostVoteSelection Fail: $t")
+                        postVoteSelectionUiState.value = PostVoteSelectionUiState(throwError = true)
+                    }
+                }
+
+                override fun onError(e: Throwable) {
+                    Log.d(TAG, e.stackTraceToString())
+                    postVoteSelectionUiState.value = PostVoteSelectionUiState(throwError = true)
+                }
+
+            }))
+    }
+
+    companion object {
+        const val TAG = "VoteViewModel"
+    }
 }

--- a/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/vote/detail/DetailVoteScreen.kt
+++ b/app/src/main/java/com/teamnoyes/balancevote/presentation/ui/screens/vote/detail/DetailVoteScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
 import com.teamnoyes.balancevote.R
 import com.teamnoyes.balancevote.presentation.ui.theme.BalanceVoteTheme
 import com.teamnoyes.balancevote.presentation.ui.widget.BVComment
@@ -84,7 +85,9 @@ fun VoteTitle(modifier: Modifier, leftTopic: String, rightTopic: String) {
 @Composable
 fun VoteBody(modifier: Modifier) {
     Surface(
-        modifier = modifier.fillMaxWidth().height(450.dp),
+        modifier = modifier
+            .fillMaxWidth()
+            .height(450.dp),
         elevation = 4.dp,
         shape = RoundedCornerShape(8.dp)
     ) {
@@ -165,13 +168,13 @@ fun ChildComment(modifier: Modifier) {
     }
 }
 
-@Preview(name = "DetailVoteScreen Light")
+@Preview(name = "DetailVoteScreen Light", showBackground = true)
 @Composable
 fun DetailVoteScreenPreviewLight() {
     DetailVoteScreenPreview(darkTheme = false)
 }
 
-@Preview(name = "DetailVoteScreen Dark")
+@Preview(name = "DetailVoteScreen Dark", showBackground = true, backgroundColor = 0x303030)
 @Composable
 fun DetailVoteScreenPreviewDark() {
     DetailVoteScreenPreview(darkTheme = true)
@@ -180,6 +183,6 @@ fun DetailVoteScreenPreviewDark() {
 @Composable
 fun DetailVoteScreenPreview(darkTheme: Boolean) {
     BalanceVoteTheme(darkTheme) {
-//        DetailVoteScreen()
+        DetailVoteScreen(rememberNavController())
     }
 }


### PR DESCRIPTION
# 주요 내용

## 에러 수정
- Composable Preview Function의 NavController Parameter를 rememberNavController()로 하여 Preview 표시
- postVoteSelection에서 id가 아닌 postId를 Parameter로 사용하게 함

## 구현
- HomeScreen에서 투표 선택 시 VoteScreen으로 이동, 두 항목을 고름
- 둘 중 하나 선택 후 postVoteSelection에서 true를 return 받으면 DetailVoteScreen으로 이동
- 투표 성공/실패 여부는 Snackbar로 표시